### PR TITLE
feat: add mask_text_input_values option for privacy-sensitive logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ st.button('my awesome button')
 page_analytics.stop_tracking()
 ```
 
+### Masking Text Input Values
+
+For privacy-sensitive applications, you can mask the values of `text_input` and `text_area` widgets in the logs by setting `mask_text_input_values=True`. When enabled, the actual input values will be replaced with `"[REDACTED]"` in the log output.
+
+```python
+import streamlit as st
+from streamlit_page_analytics import StreamlitPageAnalytics
+
+with StreamlitPageAnalytics.track(
+    name="my-app",
+    session_id=f"{session_id}",
+    user_id=f"{user_id}",
+    mask_text_input_values=True,  # Enable masking for text inputs
+):
+    st.text_input("Password")  # Value will be logged as "[REDACTED]"
+    st.text_area("Notes")      # Value will be logged as "[REDACTED]"
+    st.selectbox("Option", ["A", "B"])  # Not affected, logs actual value
+```
+
 ## Current Status
 
 The following Streamlit widgets are currently supported:

--- a/streamlit_page_analytics/streamlit_page_analytics.py
+++ b/streamlit_page_analytics/streamlit_page_analytics.py
@@ -78,6 +78,7 @@ class StreamlitPageAnalytics:
     _session_id: str
     _user_id: str
     _log_level: int
+    _mask_text_input_values: bool
 
     def __init__(
         self,
@@ -87,6 +88,7 @@ class StreamlitPageAnalytics:
         *,  # Force keyword arguments
         log_level: int = logging.INFO,
         logger: Optional[logging.Logger] = None,
+        mask_text_input_values: bool = False,
     ) -> None:
         """Initialize the StreamlitPageAnalytics instance.
 
@@ -100,6 +102,8 @@ class StreamlitPageAnalytics:
                 Can be any valid logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
             logger: An optional logger for debugging wrapper operations.
                 If not provided, a new logger will be created.
+            mask_text_input_values: If True, text input and text area values will be
+                replaced with "[REDACTED]" in the logs. Defaults to False.
         """
         self._original_mappings = {}
         self._session_id = session_id
@@ -107,6 +111,7 @@ class StreamlitPageAnalytics:
         self._log_level = log_level
         self._logger = logger if logger else logging.getLogger(name)
         self._logger.setLevel(log_level)
+        self._mask_text_input_values = mask_text_input_values
 
     def __enter__(self) -> "StreamlitPageAnalytics":
         """Enter the context manager and start tracking.
@@ -141,6 +146,7 @@ class StreamlitPageAnalytics:
         *,  # Force keyword arguments
         log_level: int = logging.INFO,
         logger: Optional[logging.Logger] = None,
+        mask_text_input_values: bool = False,
     ) -> "StreamlitPageAnalytics":
         """Create a new StreamlitPageAnalytics instance for use as a context manager.
 
@@ -154,6 +160,8 @@ class StreamlitPageAnalytics:
             log_level: Logging level for captured events. Defaults to logging.INFO.
             logger: An optional logger for debugging wrapper operations.
                 If not provided, a new logger will be created.
+            mask_text_input_values: If True, text input and text area values will be
+                replaced with "[REDACTED]" in the logs. Defaults to False.
 
         Returns:
             A new StreamlitPageAnalytics instance configured with the provided
@@ -173,6 +181,7 @@ class StreamlitPageAnalytics:
             user_id=user_id,
             log_level=log_level,
             logger=logger,
+            mask_text_input_values=mask_text_input_values,
         )
 
     def log_event(self, partial_event: UserEvent) -> None:
@@ -272,6 +281,7 @@ class StreamlitPageAnalytics:
                     event_logger_fn=self.log_event,
                     # pylint: disable=unnecessary-lambda
                     session_state_fn=lambda: st.session_state.to_dict(),
+                    mask_text_input_values=self._mask_text_input_values,
                 )
 
                 self._logger.debug(

--- a/streamlit_page_analytics/widgets/wrapped_widget.py
+++ b/streamlit_page_analytics/widgets/wrapped_widget.py
@@ -31,6 +31,7 @@ class WrappedWidget:
     _logger: logging.Logger
     _event_logger_fn: Callable[[UserEvent], None]
     _session_state_fn: Callable[[], dict[str, Any]]
+    _mask_text_input_values: bool
 
     def __init__(
         self,
@@ -38,6 +39,8 @@ class WrappedWidget:
         widget_fn: Callable,
         event_logger_fn: Callable[[UserEvent], None],
         session_state_fn: Callable[[], dict[str, Any]],
+        *,
+        mask_text_input_values: bool = False,
     ) -> None:
         """Initialize the WrappedWidget."""
         self._widget_mapping = widget_mapping
@@ -45,6 +48,7 @@ class WrappedWidget:
         self._logger = logging.getLogger(__name__)
         self._event_logger_fn = event_logger_fn
         self._session_state_fn = session_state_fn
+        self._mask_text_input_values = mask_text_input_values
 
     def wrapped_widget_fn(self, *args: List[Any], **kwargs: Dict[str, Any]) -> Any:
         """Wrapper function that adds analytics to widget interactions.
@@ -91,6 +95,7 @@ class WrappedWidget:
                 original_element_callback=extracted_widget.original_action_callback_fn,
                 logger_fn=self._event_logger_fn,
                 session_state_fn=self._session_state_fn,
+                mask_text_input_values=self._mask_text_input_values,
             )
             kwargs_to_use[extraction_attributes["action"].name] = (
                 user_event_logger.logging_callback_fn

--- a/tests/test_mask_text_input.py
+++ b/tests/test_mask_text_input.py
@@ -1,0 +1,174 @@
+# Copyright 2025 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the mask_text_input_values feature.
+
+This module contains tests that verify text input and text area values
+are properly masked when mask_text_input_values=True is set.
+"""
+
+import io
+import json
+import logging
+
+from streamlit.testing.v1 import AppTest
+
+from streamlit_page_analytics import StreamlitPageAnalytics
+
+
+# pylint: disable=no-member
+def test_text_input_masked_when_enabled() -> None:
+    """Test that text input values are masked when mask_text_input_values=True."""
+
+    def app() -> None:
+        # pylint: disable=import-outside-toplevel
+        import streamlit as st
+
+        st.text_input("Sensitive Input", key="sensitive_text")
+
+    log_stream = io.StringIO()
+    logger = logging.getLogger("test-mask-text-input")
+    logger.addHandler(logging.StreamHandler(log_stream))
+
+    with StreamlitPageAnalytics.track(
+        name="test-app",
+        session_id="test-session",
+        user_id="test-user",
+        logger=logger,
+        mask_text_input_values=True,
+    ):
+        at = AppTest.from_function(app)
+        at.run()
+
+        text_input = at.text_input[0]
+        text_input.set_value("my secret password")
+        at.run()
+
+    log_lines = log_stream.getvalue().splitlines()
+    assert len(log_lines) == 1, f"Expected 1 log line, got {len(log_lines)}"
+
+    log_json = json.loads(log_lines[0])
+
+    # Verify the value is redacted, not the actual input
+    assert log_json["widget"]["values"]["current"] == "[REDACTED]"
+    assert "my secret password" not in log_stream.getvalue()
+
+
+def test_text_area_masked_when_enabled() -> None:
+    """Test that text area values are masked when mask_text_input_values=True."""
+
+    def app() -> None:
+        # pylint: disable=import-outside-toplevel
+        import streamlit as st
+
+        st.text_area("Sensitive Text Area", key="sensitive_area")
+
+    log_stream = io.StringIO()
+    logger = logging.getLogger("test-mask-text-area")
+    logger.addHandler(logging.StreamHandler(log_stream))
+
+    with StreamlitPageAnalytics.track(
+        name="test-app",
+        session_id="test-session",
+        user_id="test-user",
+        logger=logger,
+        mask_text_input_values=True,
+    ):
+        at = AppTest.from_function(app)
+        at.run()
+
+        text_area = at.text_area[0]
+        text_area.set_value("confidential information\nwith multiple lines")
+        at.run()
+
+    log_lines = log_stream.getvalue().splitlines()
+    assert len(log_lines) == 1, f"Expected 1 log line, got {len(log_lines)}"
+
+    log_json = json.loads(log_lines[0])
+
+    # Verify the value is redacted, not the actual input
+    assert log_json["widget"]["values"]["current"] == "[REDACTED]"
+    assert "confidential information" not in log_stream.getvalue()
+
+
+def test_text_input_not_masked_when_disabled() -> None:
+    """Test text input values are NOT masked when mask_text_input_values=False."""
+
+    def app() -> None:
+        # pylint: disable=import-outside-toplevel
+        import streamlit as st
+
+        st.text_input("Normal Input", key="normal_text")
+
+    log_stream = io.StringIO()
+    logger = logging.getLogger("test-no-mask-text-input")
+    logger.addHandler(logging.StreamHandler(log_stream))
+
+    with StreamlitPageAnalytics.track(
+        name="test-app",
+        session_id="test-session",
+        user_id="test-user",
+        logger=logger,
+        mask_text_input_values=False,
+    ):
+        at = AppTest.from_function(app)
+        at.run()
+
+        text_input = at.text_input[0]
+        text_input.set_value("visible text value")
+        at.run()
+
+    log_lines = log_stream.getvalue().splitlines()
+    assert len(log_lines) == 1, f"Expected 1 log line, got {len(log_lines)}"
+
+    log_json = json.loads(log_lines[0])
+
+    # Verify the actual value is logged
+    assert log_json["widget"]["values"]["current"] == "visible text value"
+
+
+def test_other_widgets_not_affected_by_masking() -> None:
+    """Test that other widgets (selectbox) are not affected by masking."""
+
+    def app() -> None:
+        # pylint: disable=import-outside-toplevel
+        import streamlit as st
+
+        st.selectbox("Choose Option", options=["Option A", "Option B"], key="select")
+
+    log_stream = io.StringIO()
+    logger = logging.getLogger("test-other-widgets")
+    logger.addHandler(logging.StreamHandler(log_stream))
+
+    with StreamlitPageAnalytics.track(
+        name="test-app",
+        session_id="test-session",
+        user_id="test-user",
+        logger=logger,
+        mask_text_input_values=True,
+    ):
+        at = AppTest.from_function(app)
+        at.run()
+
+        selectbox = at.selectbox[0]
+        selectbox.set_value("Option B")
+        at.run()
+
+    log_lines = log_stream.getvalue().splitlines()
+    assert len(log_lines) == 1, f"Expected 1 log line, got {len(log_lines)}"
+
+    log_json = json.loads(log_lines[0])
+
+    # Verify selectbox value is NOT masked
+    assert log_json["widget"]["values"]["current"] == "Option B"


### PR DESCRIPTION
Add a new toggle parameter `mask_text_input_values` that when enabled, replaces `text_input` and `text_area` values with "[REDACTED]" in logs. This allows privacy-sensitive applications to track widget interactions without exposing potentially sensitive user input content.

Fixes #10