### PR TITLE
feat: add page tracking to log page visits on navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,35 @@ st.button('my awesome button')
 page_analytics.stop_tracking()
 ```
 
+### Page Tracking
+
+Track page visits in multi-page Streamlit applications by passing a `page_name` to `start_tracking()`. A `start_tracking` event is logged only when the user navigates to a different page, avoiding duplicate logs on page reruns.
+
+```python
+import streamlit as st
+from streamlit_page_analytics import StreamlitPageAnalytics
+
+page_analytics = StreamlitPageAnalytics(
+    name="my-app", session_id=f"{session_id}", user_id=f"{user_id}"
+)
+
+# Pass the current page name - logs only when page changes
+page_analytics.start_tracking(page_name="Home")
+
+st.title("Home Page")
+st.button("Click me")
+
+page_analytics.stop_tracking()
+```
+
+When the user navigates between pages:
+- `start_tracking(page_name="Home")` - Logs (first visit)
+- `start_tracking(page_name="Home")` - No log (same page, e.g., rerun)
+- `start_tracking(page_name="Settings")` - Logs (different page)
+- `start_tracking(page_name="Home")` - Logs (navigated back)
+
+If `page_name` is not provided or is empty, no page tracking event is logged.
+
 ### Masking Text Input Values
 
 For privacy-sensitive applications, you can mask the values of `text_input` and `text_area` widgets in the logs by setting `mask_text_input_values=True`. When enabled, the actual input values will be replaced with `"[REDACTED]"` in the log output.

--- a/streamlit_page_analytics/__init__.py
+++ b/streamlit_page_analytics/__init__.py
@@ -33,7 +33,7 @@ Example:
 from .streamlit_page_analytics import StreamlitPageAnalytics
 
 try:
-    from ._version import __version__  # type: ignore[import-not-found]
+    from ._version import __version__
 except ImportError:
     # Fallback for development installations
     from importlib.metadata import version

--- a/streamlit_page_analytics/models/user_event_action.py
+++ b/streamlit_page_analytics/models/user_event_action.py
@@ -28,6 +28,7 @@ class UserEventAction(Enum):
         OTHER: Any other type of action not covered by the above categories.
     """
 
+    START_TRACKING = "start_tracking"
     CLICK = "click"
     CHANGE = "change"
     SUBMIT = "submit"  # noqa: F841  # vulture: ignore - used in form submissions

--- a/tests/test_mask_text_input.py
+++ b/tests/test_mask_text_input.py
@@ -27,6 +27,16 @@ from streamlit.testing.v1 import AppTest
 from streamlit_page_analytics import StreamlitPageAnalytics
 
 
+def _filter_widget_logs(log_lines: list[str]) -> list[dict]:
+    """Filter log lines to only include widget interaction logs (not start_tracking)."""
+    result = []
+    for line in log_lines:
+        log_json = json.loads(line)
+        if log_json.get("action") != "start_tracking":
+            result.append(log_json)
+    return result
+
+
 # pylint: disable=no-member
 def test_text_input_masked_when_enabled() -> None:
     """Test that text input values are masked when mask_text_input_values=True."""
@@ -56,9 +66,10 @@ def test_text_input_masked_when_enabled() -> None:
         at.run()
 
     log_lines = log_stream.getvalue().splitlines()
-    assert len(log_lines) == 1, f"Expected 1 log line, got {len(log_lines)}"
+    widget_logs = _filter_widget_logs(log_lines)
+    assert len(widget_logs) == 1, f"Expected 1 widget log, got {len(widget_logs)}"
 
-    log_json = json.loads(log_lines[0])
+    log_json = widget_logs[0]
 
     # Verify the value is redacted, not the actual input
     assert log_json["widget"]["values"]["current"] == "[REDACTED]"
@@ -93,9 +104,10 @@ def test_text_area_masked_when_enabled() -> None:
         at.run()
 
     log_lines = log_stream.getvalue().splitlines()
-    assert len(log_lines) == 1, f"Expected 1 log line, got {len(log_lines)}"
+    widget_logs = _filter_widget_logs(log_lines)
+    assert len(widget_logs) == 1, f"Expected 1 widget log, got {len(widget_logs)}"
 
-    log_json = json.loads(log_lines[0])
+    log_json = widget_logs[0]
 
     # Verify the value is redacted, not the actual input
     assert log_json["widget"]["values"]["current"] == "[REDACTED]"
@@ -130,9 +142,10 @@ def test_text_input_not_masked_when_disabled() -> None:
         at.run()
 
     log_lines = log_stream.getvalue().splitlines()
-    assert len(log_lines) == 1, f"Expected 1 log line, got {len(log_lines)}"
+    widget_logs = _filter_widget_logs(log_lines)
+    assert len(widget_logs) == 1, f"Expected 1 widget log, got {len(widget_logs)}"
 
-    log_json = json.loads(log_lines[0])
+    log_json = widget_logs[0]
 
     # Verify the actual value is logged
     assert log_json["widget"]["values"]["current"] == "visible text value"
@@ -166,9 +179,10 @@ def test_other_widgets_not_affected_by_masking() -> None:
         at.run()
 
     log_lines = log_stream.getvalue().splitlines()
-    assert len(log_lines) == 1, f"Expected 1 log line, got {len(log_lines)}"
+    widget_logs = _filter_widget_logs(log_lines)
+    assert len(widget_logs) == 1, f"Expected 1 widget log, got {len(widget_logs)}"
 
-    log_json = json.loads(log_lines[0])
+    log_json = widget_logs[0]
 
     # Verify selectbox value is NOT masked
     assert log_json["widget"]["values"]["current"] == "Option B"

--- a/tests/test_page_tracking.py
+++ b/tests/test_page_tracking.py
@@ -1,0 +1,288 @@
+# Copyright 2025 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for page tracking functionality in StreamlitPageAnalytics.
+
+This module contains tests verifying that start_tracking() correctly logs
+page visits only when the page name changes.
+"""
+
+import io
+import json
+import logging
+from typing import Any, Dict, List, Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from streamlit_page_analytics import StreamlitPageAnalytics
+
+# Constants for testing
+_TEST_SESSION_ID = "test-session"
+_TEST_USER_ID = "test-user"
+_TEST_APP_NAME = "test-app"
+
+
+@pytest.fixture
+def mock_session_state() -> MagicMock:
+    """Create a mock session state that behaves like a dict."""
+    state: Dict[str, Any] = {}
+
+    def get(key: str, default: Any = None) -> Any:
+        return state.get(key, default)
+
+    mock = MagicMock()
+    mock.get = get
+    mock.__setitem__ = lambda _, key, value: state.__setitem__(key, value)
+    mock.__getitem__ = lambda _, key: state[key]
+    mock.to_dict = state.copy
+    return mock
+
+
+def _create_analytics_with_logger() -> Tuple[StreamlitPageAnalytics, io.StringIO]:
+    """Create a StreamlitPageAnalytics instance with a captured log stream."""
+    log_stream = io.StringIO()
+    logger = logging.getLogger("test-page-tracking")
+    logger.handlers = []  # Clear any existing handlers
+    logger.addHandler(logging.StreamHandler(log_stream))
+    logger.setLevel(logging.INFO)
+
+    analytics = StreamlitPageAnalytics(
+        name=_TEST_APP_NAME,
+        session_id=_TEST_SESSION_ID,
+        user_id=_TEST_USER_ID,
+        logger=logger,
+    )
+    return analytics, log_stream
+
+
+def _get_log_lines(log_stream: io.StringIO) -> List[Dict[str, Any]]:
+    """Parse log lines from the log stream."""
+    log_stream.seek(0)
+    return [json.loads(line) for line in log_stream.getvalue().splitlines() if line]
+
+
+class TestPageTracking:
+    """Tests for page tracking functionality."""
+
+    def test_start_tracking_with_page_name_logs_on_first_call(
+        self, mock_session_state: MagicMock
+    ) -> None:
+        """Test that start_tracking with page_name logs on first call."""
+        with patch("streamlit_page_analytics.streamlit_page_analytics.st") as mock_st:
+            mock_st.session_state = mock_session_state
+
+            analytics, log_stream = _create_analytics_with_logger()
+            analytics.start_tracking(page_name="Home")
+
+            log_lines = _get_log_lines(log_stream)
+            assert len(log_lines) == 1
+            assert log_lines[0]["action"] == "start_tracking"
+            assert log_lines[0]["extra"]["page_name"] == "Home"
+            assert log_lines[0]["session_id"] == _TEST_SESSION_ID
+            assert log_lines[0]["user_id"] == _TEST_USER_ID
+
+    def test_start_tracking_same_page_does_not_log_again(
+        self, mock_session_state: MagicMock
+    ) -> None:
+        """Test that calling start_tracking with same page_name does not log again."""
+        with patch("streamlit_page_analytics.streamlit_page_analytics.st") as mock_st:
+            mock_st.session_state = mock_session_state
+
+            analytics, log_stream = _create_analytics_with_logger()
+
+            # First call - should log
+            analytics.start_tracking(page_name="Home")
+
+            # Second call with same page - should NOT log
+            analytics.start_tracking(page_name="Home")
+
+            # Third call with same page - should NOT log
+            analytics.start_tracking(page_name="Home")
+
+            log_lines = _get_log_lines(log_stream)
+            assert len(log_lines) == 1  # Only one log entry
+            assert log_lines[0]["extra"]["page_name"] == "Home"
+
+    def test_start_tracking_different_page_logs_again(
+        self, mock_session_state: MagicMock
+    ) -> None:
+        """Test that changing page_name triggers a new log."""
+        with patch("streamlit_page_analytics.streamlit_page_analytics.st") as mock_st:
+            mock_st.session_state = mock_session_state
+
+            analytics, log_stream = _create_analytics_with_logger()
+
+            # First call - logs "Home"
+            analytics.start_tracking(page_name="Home")
+
+            # Second call with different page - logs "Settings"
+            analytics.start_tracking(page_name="Settings")
+
+            log_lines = _get_log_lines(log_stream)
+            assert len(log_lines) == 2
+            assert log_lines[0]["extra"]["page_name"] == "Home"
+            assert log_lines[1]["extra"]["page_name"] == "Settings"
+
+    def test_start_tracking_page_navigation_sequence(
+        self, mock_session_state: MagicMock
+    ) -> None:
+        """Test a realistic page navigation sequence."""
+        with patch("streamlit_page_analytics.streamlit_page_analytics.st") as mock_st:
+            mock_st.session_state = mock_session_state
+
+            analytics, log_stream = _create_analytics_with_logger()
+
+            # Simulate user navigating: Home -> Settings -> Home -> Settings
+            analytics.start_tracking(page_name="Home")  # Log
+            analytics.start_tracking(page_name="Home")  # No log (same page)
+            analytics.start_tracking(page_name="Settings")  # Log
+            analytics.start_tracking(page_name="Settings")  # No log (same page)
+            analytics.start_tracking(page_name="Home")  # Log (back to Home)
+            analytics.start_tracking(page_name="Settings")  # Log
+
+            log_lines = _get_log_lines(log_stream)
+            assert len(log_lines) == 4
+            assert [line["extra"]["page_name"] for line in log_lines] == [
+                "Home",
+                "Settings",
+                "Home",
+                "Settings",
+            ]
+
+    def test_start_tracking_without_page_name_does_not_log(
+        self, mock_session_state: MagicMock
+    ) -> None:
+        """Test that start_tracking without page_name does not log any event."""
+        with patch("streamlit_page_analytics.streamlit_page_analytics.st") as mock_st:
+            mock_st.session_state = mock_session_state
+
+            analytics, log_stream = _create_analytics_with_logger()
+
+            # Call without page_name - should NOT log
+            analytics.start_tracking()
+
+            # Second call without page_name - should NOT log
+            analytics.start_tracking()
+
+            log_lines = _get_log_lines(log_stream)
+            assert len(log_lines) == 0  # No log entries
+
+    def test_start_tracking_mixed_page_name_and_no_page_name(
+        self, mock_session_state: MagicMock
+    ) -> None:
+        """Test behavior when mixing calls with and without page_name."""
+        with patch("streamlit_page_analytics.streamlit_page_analytics.st") as mock_st:
+            mock_st.session_state = mock_session_state
+
+            analytics, log_stream = _create_analytics_with_logger()
+
+            # Call without page_name first - no log
+            analytics.start_tracking()
+
+            # Call with page_name - logs
+            analytics.start_tracking(page_name="Home")
+
+            # Call with same page_name - no log
+            analytics.start_tracking(page_name="Home")
+
+            # Call without page_name again - no log
+            analytics.start_tracking()
+
+            # Call with different page_name - logs
+            analytics.start_tracking(page_name="Settings")
+
+            log_lines = _get_log_lines(log_stream)
+            assert len(log_lines) == 2
+            assert log_lines[0]["extra"]["page_name"] == "Home"
+            assert log_lines[1]["extra"]["page_name"] == "Settings"
+
+    def test_separate_analytics_instances_have_independent_tracking(
+        self, mock_session_state: MagicMock
+    ) -> None:
+        """Test that different analytics instances track independently."""
+        with patch("streamlit_page_analytics.streamlit_page_analytics.st") as mock_st:
+            mock_st.session_state = mock_session_state
+
+            # Create two separate analytics instances with different names
+            log_stream1 = io.StringIO()
+            logger1 = logging.getLogger("test-page-tracking-1")
+            logger1.handlers = []
+            logger1.addHandler(logging.StreamHandler(log_stream1))
+            logger1.setLevel(logging.INFO)
+            analytics1 = StreamlitPageAnalytics(
+                name="app1",
+                session_id=_TEST_SESSION_ID,
+                user_id=_TEST_USER_ID,
+                logger=logger1,
+            )
+
+            log_stream2 = io.StringIO()
+            logger2 = logging.getLogger("test-page-tracking-2")
+            logger2.handlers = []
+            logger2.addHandler(logging.StreamHandler(log_stream2))
+            logger2.setLevel(logging.INFO)
+            analytics2 = StreamlitPageAnalytics(
+                name="app2",
+                session_id=_TEST_SESSION_ID,
+                user_id=_TEST_USER_ID,
+                logger=logger2,
+            )
+
+            # Each instance should log independently
+            analytics1.start_tracking(page_name="Home")
+            analytics2.start_tracking(page_name="Home")
+
+            log_lines1 = _get_log_lines(log_stream1)
+            log_lines2 = _get_log_lines(log_stream2)
+
+            assert len(log_lines1) == 1
+            assert len(log_lines2) == 1
+
+    def test_start_tracking_with_empty_string_page_name_does_not_log(
+        self, mock_session_state: MagicMock
+    ) -> None:
+        """Test that empty string page name does not trigger logging."""
+        with patch("streamlit_page_analytics.streamlit_page_analytics.st") as mock_st:
+            mock_st.session_state = mock_session_state
+
+            analytics, log_stream = _create_analytics_with_logger()
+
+            # Empty string should not log
+            analytics.start_tracking(page_name="")
+            analytics.start_tracking(page_name="")
+
+            log_lines = _get_log_lines(log_stream)
+            assert len(log_lines) == 0  # No log entries for empty page name
+
+    def test_start_tracking_page_name_is_case_sensitive(
+        self, mock_session_state: MagicMock
+    ) -> None:
+        """Test that page names are case sensitive."""
+        with patch("streamlit_page_analytics.streamlit_page_analytics.st") as mock_st:
+            mock_st.session_state = mock_session_state
+
+            analytics, log_stream = _create_analytics_with_logger()
+
+            analytics.start_tracking(page_name="Home")
+            analytics.start_tracking(page_name="home")  # Different - should log
+            analytics.start_tracking(page_name="HOME")  # Different - should log
+
+            log_lines = _get_log_lines(log_stream)
+            assert len(log_lines) == 3
+            assert [line["extra"]["page_name"] for line in log_lines] == [
+                "Home",
+                "home",
+                "HOME",
+            ]

--- a/tests/testing_framework.py
+++ b/tests/testing_framework.py
@@ -29,7 +29,7 @@ def _assert_equals(
     expected: Any, actual: Any, field_name: Optional[str] = None
 ) -> None:
     """Assert that two values are equal or raise an AssertionError."""
-    error_msg = f"""Mismatch {field_name + '|'  if field_name else ''}
+    error_msg = f"""Mismatch {field_name + '|' if field_name else ''}
     Expected: {expected}, Actual: {actual}
     """
     assert expected == actual, error_msg


### PR DESCRIPTION
Add optional `page_name` parameter to `start_tracking()` that logs a START_TRACKING event only when the user navigates to a different page. This prevents duplicate logs on Streamlit reruns while still capturing meaningful page navigation events.

- Only logs when page_name is provided and non-empty
- Tracks last visited page in session state per analytics instance
- Skips logging when same page is visited consecutively (e.g., reruns)
- Logs when navigating to a different page

Fixes #11