### PR TITLE
refactor(tests): streamline run_widget_interaction_test with **kwargs

### DIFF
--- a/tests/test_log_identifiers.py
+++ b/tests/test_log_identifiers.py
@@ -1,0 +1,247 @@
+# Copyright 2025 Snowflake Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for verifying session_id and user_id are correctly logged.
+
+This module contains tests that verify the provided session_id and user_id
+values are correctly included in all log entries.
+"""
+
+from streamlit.testing.v1 import AppTest
+from testing_framework import run_widget_interaction_test
+
+
+def test_custom_session_id_in_logs() -> None:
+    """Test that a custom session_id is correctly included in logs."""
+
+    def widget_interaction() -> None:
+        def app() -> None:
+            # pylint: disable=import-outside-toplevel
+            import streamlit as st
+
+            st.button("Test Button", key="test_btn")
+
+        at = AppTest.from_function(app)
+        at.run()
+
+        button = at.button[0]
+        button.click()
+        at.run()
+
+    expected_log = [
+        {
+            "action": "click",
+            "widget": {
+                "id": "test_btn",
+                "type": "button",
+                "label": "Test Button",
+            },
+        }
+    ]
+
+    run_widget_interaction_test(
+        widget_interaction,
+        expected_log,
+        session_id="custom-session-abc123",
+    )
+
+
+def test_custom_user_id_in_logs() -> None:
+    """Test that a custom user_id is correctly included in logs."""
+
+    def widget_interaction() -> None:
+        def app() -> None:
+            # pylint: disable=import-outside-toplevel
+            import streamlit as st
+
+            st.checkbox("Test Checkbox", key="test_cb")
+
+        at = AppTest.from_function(app)
+        at.run()
+
+        checkbox = at.checkbox[0]
+        checkbox.check()
+        at.run()
+
+    expected_log = [
+        {
+            "action": "change",
+            "widget": {
+                "id": "test_cb",
+                "type": "checkbox",
+                "label": "Test Checkbox",
+                "values": {"current": True},
+            },
+        }
+    ]
+
+    run_widget_interaction_test(
+        widget_interaction,
+        expected_log,
+        user_id="user-xyz-789",
+    )
+
+
+def test_custom_session_id_and_user_id_in_logs() -> None:
+    """Test that both custom session_id and user_id are correctly included."""
+
+    def widget_interaction() -> None:
+        def app() -> None:
+            # pylint: disable=import-outside-toplevel
+            import streamlit as st
+
+            st.slider("Test Slider", min_value=0, max_value=100, key="test_slider")
+
+        at = AppTest.from_function(app)
+        at.run()
+
+        slider = at.slider[0]
+        slider.set_value(50)
+        at.run()
+
+    expected_log = [
+        {
+            "action": "change",
+            "widget": {
+                "id": "test_slider",
+                "type": "slider",
+                "label": "Test Slider",
+                "values": {"current": 50},
+            },
+        }
+    ]
+
+    run_widget_interaction_test(
+        widget_interaction,
+        expected_log,
+        session_id="session-unique-456",
+        user_id="user-unique-123",
+    )
+
+
+def test_multiple_interactions_have_consistent_ids() -> None:
+    """Test that session_id and user_id remain consistent across multiple interactions."""
+
+    def widget_interaction() -> None:
+        def app() -> None:
+            # pylint: disable=import-outside-toplevel
+            import streamlit as st
+
+            st.button("Button 1", key="btn1")
+            st.button("Button 2", key="btn2")
+
+        at = AppTest.from_function(app)
+        at.run()
+
+        at.button[0].click()
+        at.run()
+
+        at.button[1].click()
+        at.run()
+
+    expected_log = [
+        {
+            "action": "click",
+            "widget": {
+                "id": "btn1",
+                "type": "button",
+                "label": "Button 1",
+            },
+        },
+        {
+            "action": "click",
+            "widget": {
+                "id": "btn2",
+                "type": "button",
+                "label": "Button 2",
+            },
+        },
+    ]
+
+    run_widget_interaction_test(
+        widget_interaction,
+        expected_log,
+        session_id="persistent-session",
+        user_id="persistent-user",
+    )
+
+
+def test_special_characters_in_session_id() -> None:
+    """Test that session_id with special characters is handled correctly."""
+
+    def widget_interaction() -> None:
+        def app() -> None:
+            # pylint: disable=import-outside-toplevel
+            import streamlit as st
+
+            st.button("Test Button", key="test_btn")
+
+        at = AppTest.from_function(app)
+        at.run()
+
+        button = at.button[0]
+        button.click()
+        at.run()
+
+    expected_log = [
+        {
+            "action": "click",
+            "widget": {
+                "id": "test_btn",
+                "type": "button",
+                "label": "Test Button",
+            },
+        }
+    ]
+
+    run_widget_interaction_test(
+        widget_interaction,
+        expected_log,
+        session_id="session_with-special.chars@123",
+    )
+
+
+def test_special_characters_in_user_id() -> None:
+    """Test that user_id with special characters is handled correctly."""
+
+    def widget_interaction() -> None:
+        def app() -> None:
+            # pylint: disable=import-outside-toplevel
+            import streamlit as st
+
+            st.button("Test Button", key="test_btn")
+
+        at = AppTest.from_function(app)
+        at.run()
+
+        button = at.button[0]
+        button.click()
+        at.run()
+
+    expected_log = [
+        {
+            "action": "click",
+            "widget": {
+                "id": "test_btn",
+                "type": "button",
+                "label": "Test Button",
+            },
+        }
+    ]
+
+    run_widget_interaction_test(
+        widget_interaction,
+        expected_log,
+        user_id="user@example.com",
+    )

--- a/tests/test_mask_all_values.py
+++ b/tests/test_mask_all_values.py
@@ -18,46 +18,21 @@ This module contains tests that verify all widget values
 are properly masked when mask_all_values=True is set.
 """
 
-import io
-import json
-import logging
-
 from streamlit.testing.v1 import AppTest
-
-from streamlit_page_analytics import StreamlitPageAnalytics
-
-
-def _filter_widget_logs(log_lines: list[str]) -> list[dict]:
-    """Filter log lines to only include widget interaction logs (not start_tracking)."""
-    result = []
-    for line in log_lines:
-        log_json = json.loads(line)
-        if log_json.get("action") != "start_tracking":
-            result.append(log_json)
-    return result
+from testing_framework import run_widget_interaction_test
 
 
 # pylint: disable=no-member
 def test_text_input_masked_when_mask_all_values_enabled() -> None:
     """Test that text input values are masked when mask_all_values=True."""
 
-    def app() -> None:
-        # pylint: disable=import-outside-toplevel
-        import streamlit as st
+    def widget_interaction() -> None:
+        def app() -> None:
+            # pylint: disable=import-outside-toplevel
+            import streamlit as st
 
-        st.text_input("Sensitive Input", key="sensitive_text")
+            st.text_input("Sensitive Input", key="sensitive_text")
 
-    log_stream = io.StringIO()
-    logger = logging.getLogger("test-mask-all-text-input")
-    logger.addHandler(logging.StreamHandler(log_stream))
-
-    with StreamlitPageAnalytics.track(
-        name="test-app",
-        session_id="test-session",
-        user_id="test-user",
-        logger=logger,
-        mask_all_values=True,
-    ):
         at = AppTest.from_function(app)
         at.run()
 
@@ -65,36 +40,31 @@ def test_text_input_masked_when_mask_all_values_enabled() -> None:
         text_input.set_value("my secret password")
         at.run()
 
-    log_lines = log_stream.getvalue().splitlines()
-    widget_logs = _filter_widget_logs(log_lines)
-    assert len(widget_logs) == 1, f"Expected 1 widget log, got {len(widget_logs)}"
+    expected_log = [
+        {
+            "action": "change",
+            "widget": {
+                "id": "sensitive_text",
+                "type": "text_input",
+                "label": "Sensitive Input",
+                "values": {"current": "[REDACTED]"},
+            },
+        }
+    ]
 
-    log_json = widget_logs[0]
-
-    assert log_json["widget"]["values"]["current"] == "[REDACTED]"
-    assert "my secret password" not in log_stream.getvalue()
+    run_widget_interaction_test(widget_interaction, expected_log, mask_all_values=True)
 
 
 def test_selectbox_masked_when_mask_all_values_enabled() -> None:
     """Test that selectbox values are masked when mask_all_values=True."""
 
-    def app() -> None:
-        # pylint: disable=import-outside-toplevel
-        import streamlit as st
+    def widget_interaction() -> None:
+        def app() -> None:
+            # pylint: disable=import-outside-toplevel
+            import streamlit as st
 
-        st.selectbox("Choose Option", options=["Option A", "Option B"], key="select")
+            st.selectbox("Choose Option", options=["Option A", "Option B"], key="select")
 
-    log_stream = io.StringIO()
-    logger = logging.getLogger("test-mask-all-selectbox")
-    logger.addHandler(logging.StreamHandler(log_stream))
-
-    with StreamlitPageAnalytics.track(
-        name="test-app",
-        session_id="test-session",
-        user_id="test-user",
-        logger=logger,
-        mask_all_values=True,
-    ):
         at = AppTest.from_function(app)
         at.run()
 
@@ -102,36 +72,31 @@ def test_selectbox_masked_when_mask_all_values_enabled() -> None:
         selectbox.set_value("Option B")
         at.run()
 
-    log_lines = log_stream.getvalue().splitlines()
-    widget_logs = _filter_widget_logs(log_lines)
-    assert len(widget_logs) == 1, f"Expected 1 widget log, got {len(widget_logs)}"
+    expected_log = [
+        {
+            "action": "change",
+            "widget": {
+                "id": "select",
+                "type": "selectbox",
+                "label": "Choose Option",
+                "values": {"current": "[REDACTED]"},
+            },
+        }
+    ]
 
-    log_json = widget_logs[0]
-
-    assert log_json["widget"]["values"]["current"] == "[REDACTED]"
-    assert "Option B" not in json.dumps(log_json["widget"]["values"])
+    run_widget_interaction_test(widget_interaction, expected_log, mask_all_values=True)
 
 
 def test_slider_masked_when_mask_all_values_enabled() -> None:
     """Test that slider values are masked when mask_all_values=True."""
 
-    def app() -> None:
-        # pylint: disable=import-outside-toplevel
-        import streamlit as st
+    def widget_interaction() -> None:
+        def app() -> None:
+            # pylint: disable=import-outside-toplevel
+            import streamlit as st
 
-        st.slider("Choose Value", min_value=0, max_value=100, value=50, key="slider")
+            st.slider("Choose Value", min_value=0, max_value=100, value=50, key="slider")
 
-    log_stream = io.StringIO()
-    logger = logging.getLogger("test-mask-all-slider")
-    logger.addHandler(logging.StreamHandler(log_stream))
-
-    with StreamlitPageAnalytics.track(
-        name="test-app",
-        session_id="test-session",
-        user_id="test-user",
-        logger=logger,
-        mask_all_values=True,
-    ):
         at = AppTest.from_function(app)
         at.run()
 
@@ -139,35 +104,31 @@ def test_slider_masked_when_mask_all_values_enabled() -> None:
         slider.set_value(75)
         at.run()
 
-    log_lines = log_stream.getvalue().splitlines()
-    widget_logs = _filter_widget_logs(log_lines)
-    assert len(widget_logs) == 1, f"Expected 1 widget log, got {len(widget_logs)}"
+    expected_log = [
+        {
+            "action": "change",
+            "widget": {
+                "id": "slider",
+                "type": "slider",
+                "label": "Choose Value",
+                "values": {"current": "[REDACTED]"},
+            },
+        }
+    ]
 
-    log_json = widget_logs[0]
-
-    assert log_json["widget"]["values"]["current"] == "[REDACTED]"
+    run_widget_interaction_test(widget_interaction, expected_log, mask_all_values=True)
 
 
 def test_widgets_not_masked_when_mask_all_values_disabled() -> None:
     """Test that widget values are NOT masked when mask_all_values=False."""
 
-    def app() -> None:
-        # pylint: disable=import-outside-toplevel
-        import streamlit as st
+    def widget_interaction() -> None:
+        def app() -> None:
+            # pylint: disable=import-outside-toplevel
+            import streamlit as st
 
-        st.selectbox("Choose Option", options=["Option A", "Option B"], key="select")
+            st.selectbox("Choose Option", options=["Option A", "Option B"], key="select")
 
-    log_stream = io.StringIO()
-    logger = logging.getLogger("test-no-mask-all")
-    logger.addHandler(logging.StreamHandler(log_stream))
-
-    with StreamlitPageAnalytics.track(
-        name="test-app",
-        session_id="test-session",
-        user_id="test-user",
-        logger=logger,
-        mask_all_values=False,
-    ):
         at = AppTest.from_function(app)
         at.run()
 
@@ -175,10 +136,16 @@ def test_widgets_not_masked_when_mask_all_values_disabled() -> None:
         selectbox.set_value("Option B")
         at.run()
 
-    log_lines = log_stream.getvalue().splitlines()
-    widget_logs = _filter_widget_logs(log_lines)
-    assert len(widget_logs) == 1, f"Expected 1 widget log, got {len(widget_logs)}"
+    expected_log = [
+        {
+            "action": "change",
+            "widget": {
+                "id": "select",
+                "type": "selectbox",
+                "label": "Choose Option",
+                "values": {"current": "Option B"},
+            },
+        }
+    ]
 
-    log_json = widget_logs[0]
-
-    assert log_json["widget"]["values"]["current"] == "Option B"
+    run_widget_interaction_test(widget_interaction, expected_log, mask_all_values=False)

--- a/tests/testing_framework.py
+++ b/tests/testing_framework.py
@@ -19,7 +19,6 @@ from typing import Any, Callable, Dict, Optional
 
 from streamlit_page_analytics import StreamlitPageAnalytics
 
-# Constants for testing
 _TEST_SESSION_ID = "test-session"
 _TEST_USER_ID = "test-user"
 _TEST_APP_NAME = "test-app"
@@ -35,50 +34,73 @@ def _assert_equals(
     assert expected == actual, error_msg
 
 
+def _filter_widget_logs(log_lines: list[str]) -> list[dict]:
+    """Filter log lines to only include widget interaction logs (not start_tracking)."""
+    result = []
+    for line in log_lines:
+        log_json = json.loads(line)
+        if log_json.get("action") != "start_tracking":
+            result.append(log_json)
+    return result
+
+
 def run_widget_interaction_test(
-    test_code: Callable[[], None], expected_log_lines: list[Dict[str, Any]]
+    test_code: Callable[[], None],
+    expected_log_lines: list[Dict[str, Any]],
+    **analytics_kwargs: Any,
 ) -> None:
     """Run a test with StreamlitPageAnalytics and verify log output.
 
     Args:
         test_code: A callable that contains the test code to run
         expected_log_lines: The expected log lines to compare against
+        **analytics_kwargs: Additional keyword arguments to pass to
+            StreamlitPageAnalytics.track(). Supported options include:
+            - mask_all_values: bool - Mask all widget values in logs
+            - mask_text_input_values: bool - Mask text input values only
+            - logger: logging.Logger - Custom logger (default: creates new one)
+            - name: str - App name (default: "test-app")
+            - session_id: str - Session ID (default: "test-session")
+            - user_id: str - User ID (default: "test-user")
     """
     log_stream = io.StringIO()
-    logger = logging.getLogger("test-logger")
-    logger.addHandler(logging.StreamHandler(log_stream))
+    logger = analytics_kwargs.pop("logger", None)
+    if logger is None:
+        logger = logging.getLogger("test-logger")
+        logger.addHandler(logging.StreamHandler(log_stream))
+
+    name = analytics_kwargs.pop("name", _TEST_APP_NAME)
+    session_id = analytics_kwargs.pop("session_id", _TEST_SESSION_ID)
+    user_id = analytics_kwargs.pop("user_id", _TEST_USER_ID)
 
     with StreamlitPageAnalytics.track(
-        name=_TEST_APP_NAME,
-        session_id=_TEST_SESSION_ID,
-        user_id=_TEST_USER_ID,
+        name=name,
+        session_id=session_id,
+        user_id=user_id,
         logger=logger,
+        **analytics_kwargs,
     ):
         test_code()
 
     log_lines = log_stream.getvalue().splitlines()
-    assert len(log_lines) == len(
-        expected_log_lines
-    ), f"Expected {len(expected_log_lines)} log lines, got {len(log_lines)}"
+    widget_logs = _filter_widget_logs(log_lines)
 
-    # For each log line, verify that it contains the expected elements
-    # rather than requiring an exact match
-    for log_line, expected_log_line in zip(log_lines, expected_log_lines):
-        log_json = json.loads(log_line)
+    assert len(widget_logs) == len(expected_log_lines), (
+        f"Expected {len(expected_log_lines)} log lines, got {len(widget_logs)}"
+    )
 
-        # Verify session_id and user_id
+    for log_json, expected_log_line in zip(widget_logs, expected_log_lines):
         _assert_equals(
-            expected=_TEST_SESSION_ID,
+            expected=session_id,
             actual=log_json["session_id"],
             field_name="session_id",
         )
         _assert_equals(
-            expected=_TEST_USER_ID,
+            expected=user_id,
             actual=log_json["user_id"],
             field_name="user_id",
         )
 
-        # Verify action if specified in expected_elements
         if "action" in expected_log_line:
             _assert_equals(
                 expected=expected_log_line["action"],
@@ -86,7 +108,6 @@ def run_widget_interaction_test(
                 field_name="action",
             )
 
-        # Verify element_id, element_type, and label if specified in expected_elements
         if "widget" in expected_log_line and "widget" in log_json:
             _assert_equals(
                 expected=expected_log_line["widget"]["id"],


### PR DESCRIPTION
Unify the two different testing approaches into a single consistent pattern by extending run_widget_interaction_test to accept **kwargs for StreamlitPageAnalytics configuration.

Changes:
- Add **analytics_kwargs to run_widget_interaction_test for flexible configuration (mask_all_values, mask_text_input_values, session_id, user_id, name, logger)
- Add _filter_widget_logs helper to filter out start_tracking events
- Refactor test_mask_text_input.py to use the unified helper
- Refactor test_mask_all_values.py to use the unified helper
- Add test_log_identifiers.py with tests verifying session_id and user_id are correctly included in logs

Closes #20