### PR TITLE
feat: Add page_name field to UserEvent model for all log events

### DIFF
--- a/streamlit_page_analytics/models/user_event.py
+++ b/streamlit_page_analytics/models/user_event.py
@@ -30,6 +30,7 @@ class UserEvent:
         session_id: Unique identifier for the user session. Can be None if not set.
         user_id: Details about the user who performed the action. Can be None if
             not available.
+        page_name: Name of the page where the event occurred. Can be None if not set.
         action: The type of action performed, either as a string or
             UserEventAction enum. Defaults to UserEventAction.OTHER.
         widget: Details about the UI element that was interacted with. Can be
@@ -40,6 +41,7 @@ class UserEvent:
 
     session_id: Optional[str] = None
     user_id: Optional[str] = None
+    page_name: Optional[str] = None
     action: Union[str, UserEventAction] = UserEventAction.OTHER
     widget: Optional[Widget] = None
     extra: Optional[Dict[str, Any]] = None
@@ -84,6 +86,20 @@ class UserEvent:
         new.user_id = user_id
         return new
 
+    def with_page_name(self, page_name: Optional[str]) -> "UserEvent":
+        """Create a new UserEvent instance with the specified page name.
+
+        Args:
+            page_name: The name of the page where the event occurred.
+
+        Returns:
+            A new UserEvent instance identical to this one but with the
+            specified page_name value.
+        """
+        new = UserEvent(**self.__dict__)
+        new.page_name = page_name
+        return new
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert the UserEvent instance to a dictionary representation.
 
@@ -98,6 +114,7 @@ class UserEvent:
         return {
             "session_id": self.session_id,
             "user_id": self.user_id,
+            "page_name": self.page_name,
             "action": (
                 self.action.value
                 if isinstance(self.action, UserEventAction)

--- a/tests/test_page_tracking.py
+++ b/tests/test_page_tracking.py
@@ -89,7 +89,7 @@ class TestPageTracking:
             log_lines = _get_log_lines(log_stream)
             assert len(log_lines) == 1
             assert log_lines[0]["action"] == "start_tracking"
-            assert log_lines[0]["extra"]["page_name"] == "Home"
+            assert log_lines[0]["page_name"] == "Home"
             assert log_lines[0]["session_id"] == _TEST_SESSION_ID
             assert log_lines[0]["user_id"] == _TEST_USER_ID
 
@@ -113,7 +113,7 @@ class TestPageTracking:
 
             log_lines = _get_log_lines(log_stream)
             assert len(log_lines) == 1  # Only one log entry
-            assert log_lines[0]["extra"]["page_name"] == "Home"
+            assert log_lines[0]["page_name"] == "Home"
 
     def test_start_tracking_different_page_logs_again(
         self, mock_session_state: MagicMock
@@ -132,8 +132,8 @@ class TestPageTracking:
 
             log_lines = _get_log_lines(log_stream)
             assert len(log_lines) == 2
-            assert log_lines[0]["extra"]["page_name"] == "Home"
-            assert log_lines[1]["extra"]["page_name"] == "Settings"
+            assert log_lines[0]["page_name"] == "Home"
+            assert log_lines[1]["page_name"] == "Settings"
 
     def test_start_tracking_page_navigation_sequence(
         self, mock_session_state: MagicMock
@@ -154,7 +154,7 @@ class TestPageTracking:
 
             log_lines = _get_log_lines(log_stream)
             assert len(log_lines) == 4
-            assert [line["extra"]["page_name"] for line in log_lines] == [
+            assert [line["page_name"] for line in log_lines] == [
                 "Home",
                 "Settings",
                 "Home",
@@ -205,8 +205,8 @@ class TestPageTracking:
 
             log_lines = _get_log_lines(log_stream)
             assert len(log_lines) == 2
-            assert log_lines[0]["extra"]["page_name"] == "Home"
-            assert log_lines[1]["extra"]["page_name"] == "Settings"
+            assert log_lines[0]["page_name"] == "Home"
+            assert log_lines[1]["page_name"] == "Settings"
 
     def test_separate_analytics_instances_have_independent_tracking(
         self, mock_session_state: MagicMock
@@ -281,7 +281,7 @@ class TestPageTracking:
 
             log_lines = _get_log_lines(log_stream)
             assert len(log_lines) == 3
-            assert [line["extra"]["page_name"] for line in log_lines] == [
+            assert [line["page_name"] for line in log_lines] == [
                 "Home",
                 "home",
                 "HOME",


### PR DESCRIPTION
Previously, the page_name was only included in the `extra` field of START_TRACKING events. This change promotes page_name to a first-class field in the UserEvent model, ensuring it is included in all log events (widget interactions, start_tracking, etc.).

Changes:
- Add `page_name` attribute to UserEvent dataclass
- Add `with_page_name()` method for fluent API pattern
- Update `to_dict()` to include page_name in serialized output
- Store page_name in StreamlitPageAnalytics instance and enrich all events with it via `log_event()`
- Update tests to verify page_name appears at top level instead of in extra field

This enables downstream consumers to filter and analyze logs by page without needing to parse the extra field.

Fixes #18