### PR TITLE
chore(tests): resolve pylint lint errors

### DIFF
--- a/tests/test_log_identifiers.py
+++ b/tests/test_log_identifiers.py
@@ -36,7 +36,7 @@ def test_custom_session_id_in_logs() -> None:
         at.run()
 
         button = at.button[0]
-        button.click()
+        button.click()  # pylint: disable=no-member
         at.run()
 
     expected_log = [
@@ -71,7 +71,7 @@ def test_custom_user_id_in_logs() -> None:
         at.run()
 
         checkbox = at.checkbox[0]
-        checkbox.check()
+        checkbox.check()  # pylint: disable=no-member
         at.run()
 
     expected_log = [
@@ -107,7 +107,7 @@ def test_custom_session_id_and_user_id_in_logs() -> None:
         at.run()
 
         slider = at.slider[0]
-        slider.set_value(50)
+        slider.set_value(50)  # pylint: disable=no-member
         at.run()
 
     expected_log = [
@@ -131,7 +131,7 @@ def test_custom_session_id_and_user_id_in_logs() -> None:
 
 
 def test_multiple_interactions_have_consistent_ids() -> None:
-    """Test that session_id and user_id remain consistent across multiple interactions."""
+    """Test that IDs remain consistent across multiple interactions."""
 
     def widget_interaction() -> None:
         def app() -> None:
@@ -144,10 +144,10 @@ def test_multiple_interactions_have_consistent_ids() -> None:
         at = AppTest.from_function(app)
         at.run()
 
-        at.button[0].click()
+        at.button[0].click()  # pylint: disable=no-member
         at.run()
 
-        at.button[1].click()
+        at.button[1].click()  # pylint: disable=no-member
         at.run()
 
     expected_log = [
@@ -191,7 +191,7 @@ def test_special_characters_in_session_id() -> None:
         at.run()
 
         button = at.button[0]
-        button.click()
+        button.click()  # pylint: disable=no-member
         at.run()
 
     expected_log = [
@@ -226,7 +226,7 @@ def test_special_characters_in_user_id() -> None:
         at.run()
 
         button = at.button[0]
-        button.click()
+        button.click()  # pylint: disable=no-member
         at.run()
 
     expected_log = [

--- a/tests/test_mask_all_values.py
+++ b/tests/test_mask_all_values.py
@@ -63,7 +63,9 @@ def test_selectbox_masked_when_mask_all_values_enabled() -> None:
             # pylint: disable=import-outside-toplevel
             import streamlit as st
 
-            st.selectbox("Choose Option", options=["Option A", "Option B"], key="select")
+            st.selectbox(
+                "Choose Option", options=["Option A", "Option B"], key="select"
+            )
 
         at = AppTest.from_function(app)
         at.run()
@@ -95,7 +97,9 @@ def test_slider_masked_when_mask_all_values_enabled() -> None:
             # pylint: disable=import-outside-toplevel
             import streamlit as st
 
-            st.slider("Choose Value", min_value=0, max_value=100, value=50, key="slider")
+            st.slider(
+                "Choose Value", min_value=0, max_value=100, value=50, key="slider"
+            )
 
         at = AppTest.from_function(app)
         at.run()
@@ -127,7 +131,9 @@ def test_widgets_not_masked_when_mask_all_values_disabled() -> None:
             # pylint: disable=import-outside-toplevel
             import streamlit as st
 
-            st.selectbox("Choose Option", options=["Option A", "Option B"], key="select")
+            st.selectbox(
+                "Choose Option", options=["Option A", "Option B"], key="select"
+            )
 
         at = AppTest.from_function(app)
         at.run()

--- a/tests/test_mask_text_input.py
+++ b/tests/test_mask_text_input.py
@@ -133,7 +133,9 @@ def test_other_widgets_not_affected_by_masking() -> None:
             # pylint: disable=import-outside-toplevel
             import streamlit as st
 
-            st.selectbox("Choose Option", options=["Option A", "Option B"], key="select")
+            st.selectbox(
+                "Choose Option", options=["Option A", "Option B"], key="select"
+            )
 
         at = AppTest.from_function(app)
         at.run()

--- a/tests/testing_framework.py
+++ b/tests/testing_framework.py
@@ -85,9 +85,9 @@ def run_widget_interaction_test(
     log_lines = log_stream.getvalue().splitlines()
     widget_logs = _filter_widget_logs(log_lines)
 
-    assert len(widget_logs) == len(expected_log_lines), (
-        f"Expected {len(expected_log_lines)} log lines, got {len(widget_logs)}"
-    )
+    assert len(widget_logs) == len(
+        expected_log_lines
+    ), f"Expected {len(expected_log_lines)} log lines, got {len(widget_logs)}"
 
     for log_json, expected_log_line in zip(widget_logs, expected_log_lines):
         _assert_equals(


### PR DESCRIPTION
Fixes #25

This commit addresses pylint errors reported by `task lint`:

## Changes

### Line Too Long (C0301)
- Shortened docstring in `test_multiple_interactions_have_consistent_ids()`
  from 90 to 65 characters to comply with 88-char limit

### No-Member False Positives (E1101)
- Added `# pylint: disable=no-member` inline comments to suppress
  false positive errors where pylint doesn't recognize Streamlit's
  `ElementList` dynamic methods (`click()`, `check()`, `set_value()`)
- Affected lines: 39, 74, 110, 147, 150, 194, 229

## Result
- Pylint score improved: 9.52/10 → 9.92/10
- Remaining R0801 (duplicate-code) warnings are acceptable for test
  files where fixture duplication improves test isolation and clarity

Co-Authored-By: Cortex Code <noreply@snowflake.com>